### PR TITLE
Enhance adapter chaining and add tests

### DIFF
--- a/src/core/adapter-chain.ts
+++ b/src/core/adapter-chain.ts
@@ -1,0 +1,96 @@
+import { Protocol, ProtocolAdapter, AdapterContext, AdapterRegistry } from './adapter.js';
+
+/**
+ * Represents an ordered chain of protocol adapters to transform data
+ * across multiple protocol boundaries.
+ */
+export class AdapterChain<From = any, To = any> {
+    constructor(private readonly chain: ProtocolAdapter<any, any>[]) {}
+
+    /**
+     * Sequentially adapt the data through the adapter chain.
+     */
+    async adapt(data: From, context?: AdapterContext): Promise<To> {
+        let result: any = data;
+        for (const adapter of this.chain) {
+            result = await adapter.adapt(result, context);
+        }
+        return result as To;
+    }
+
+    /**
+     * Reverse the transformation through the chain in reverse order.
+     */
+    async reverse(data: To, context?: AdapterContext): Promise<From> {
+        let result: any = data;
+        for (const adapter of [...this.chain].reverse()) {
+            result = await adapter.reverse(result, context);
+        }
+        return result as From;
+    }
+
+    /**
+     * Get adapters that compose this chain.
+     */
+    getAdapters(): ProtocolAdapter<any, any>[] {
+        return [...this.chain];
+    }
+
+    get sourceProtocol(): Protocol | null {
+        return this.chain.length ? this.chain[0].sourceProtocol : null;
+    }
+
+    get targetProtocol(): Protocol | null {
+        return this.chain.length ? this.chain[this.chain.length - 1].targetProtocol : null;
+    }
+}
+
+/**
+ * Utility for discovering a chain of adapters from a registry
+ * connecting a source protocol to a target protocol.
+ */
+export class AdapterChainBuilder {
+    constructor(private readonly registry: AdapterRegistry) {}
+
+    buildChain(source: Protocol, target: Protocol): AdapterChain | null {
+        type Node = { protocol: Protocol; chain: ProtocolAdapter<any, any>[]; cost: number };
+        const queue: Node[] = [];
+        const bestCost = new Map<string, number>();
+
+        queue.push({ protocol: source, chain: [], cost: 0 });
+        bestCost.set(this.protocolKey(source), 0);
+
+        while (queue.length) {
+            queue.sort((a, b) => a.cost - b.cost);
+            const { protocol, chain, cost } = queue.shift()!;
+
+            if (this.isSameProtocol(protocol, target)) {
+                return new AdapterChain(chain);
+            }
+
+            for (const adapter of this.registry.getAdapters()) {
+                if (this.isSameProtocol(adapter.sourceProtocol, protocol)) {
+                    const next = adapter.targetProtocol;
+                    const adapterCost = 1 - adapter.getCompatibilityScore();
+                    const newCost = cost + adapterCost;
+                    const key = this.protocolKey(next);
+
+                    if (!bestCost.has(key) || newCost < bestCost.get(key)!) {
+                        bestCost.set(key, newCost);
+                        queue.push({ protocol: next, chain: [...chain, adapter], cost: newCost });
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private protocolKey(p: Protocol): string {
+        return `${p.name}@${p.version}`;
+    }
+
+    private isSameProtocol(a: Protocol, b: Protocol): boolean {
+        return a.name === b.name && a.version === b.version;
+    }
+}

--- a/src/core/adapter.ts
+++ b/src/core/adapter.ts
@@ -106,6 +106,13 @@ export class AdapterRegistry {
     }
 
     /**
+     * Get all registered adapters
+     */
+    getAdapters(): ProtocolAdapter<any, any>[] {
+        return Array.from(this.adapters.values());
+    }
+
+    /**
      * Create a unique key for adapter lookup
      */
     private getAdapterKey(source: Protocol, target: Protocol): string {

--- a/src/implementations/grpc-json.adapter.ts
+++ b/src/implementations/grpc-json.adapter.ts
@@ -1,0 +1,52 @@
+import { Protocol, ProtocolAdapter, AdapterContext } from '../core/adapter.js';
+
+interface GrpcProtocol extends Protocol {
+    services: {
+        name: string;
+        methods: {
+            name: string;
+            inputType: string;
+            outputType: string;
+        }[];
+    }[];
+}
+
+interface JsonProtocol extends Protocol {
+    schema?: Record<string, any>;
+}
+
+export class GrpcToJsonAdapter implements ProtocolAdapter<GrpcProtocol, JsonProtocol> {
+    sourceProtocol: GrpcProtocol = {
+        name: 'gRPC',
+        version: '1.0',
+        capabilities: ['Streaming', 'Protobuf'],
+        metadata: {},
+        services: []
+    };
+
+    targetProtocol: JsonProtocol = {
+        name: 'JSON',
+        version: '1.0',
+        capabilities: ['Nested', 'Arrays'],
+        metadata: {},
+        schema: {}
+    };
+
+    async adapt(data: any, context?: AdapterContext): Promise<any> {
+        const { message } = data;
+        return JSON.parse(new TextDecoder().decode(message));
+    }
+
+    async reverse(data: any, context?: AdapterContext): Promise<any> {
+        const message = new TextEncoder().encode(JSON.stringify(data));
+        return { response: message, metadata: { status: 0 } };
+    }
+
+    canHandle(source: Protocol, target: Protocol): boolean {
+        return source.name === 'gRPC' && target.name === 'JSON';
+    }
+
+    getCompatibilityScore(): number {
+        return 0.85;
+    }
+}

--- a/src/tests/core/adapter-chain.test.ts
+++ b/src/tests/core/adapter-chain.test.ts
@@ -1,0 +1,60 @@
+import { AdapterRegistry, Protocol, ProtocolAdapter } from '../../core/adapter.js';
+import { AdapterChainBuilder } from '../../core/adapter-chain.js';
+import { HttpToGrpcAdapter } from '../../implementations/http-grpc.adapter.js';
+import { GrpcToJsonAdapter } from '../../implementations/grpc-json.adapter.js';
+import { JsonToXmlAdapter } from '../../implementations/json-xml.adapter.js';
+import { createMockContext } from '../utils/test-helpers.js';
+
+describe('AdapterChainBuilder', () => {
+    it('should build a chain from HTTP to XML', async () => {
+        const registry = new AdapterRegistry();
+        registry.register(new HttpToGrpcAdapter());
+        registry.register(new GrpcToJsonAdapter());
+        registry.register(new JsonToXmlAdapter());
+
+        const builder = new AdapterChainBuilder(registry);
+        const chain = builder.buildChain(
+            { name: 'HTTP', version: '1.1', capabilities: [], metadata: {} },
+            { name: 'XML', version: '1.0', capabilities: [], metadata: {} }
+        );
+
+        expect(chain).toBeTruthy();
+
+        const httpRequest = {
+            method: 'POST',
+            path: '/users',
+            body: { name: 'Alice' }
+        };
+
+        const xml = await chain!.adapt(httpRequest, createMockContext());
+        expect(xml).toContain('<name>Alice</name>');
+    });
+
+    it('should prefer the highest compatibility chain', () => {
+        const registry = new AdapterRegistry();
+
+        class HttpToJsonLowCompat implements ProtocolAdapter<Protocol, Protocol> {
+            sourceProtocol = { name: 'HTTP', version: '1.1', capabilities: [], metadata: {} };
+            targetProtocol = { name: 'JSON', version: '1.0', capabilities: [], metadata: {} };
+            adapt = async (d: any) => d;
+            reverse = async (d: any) => d;
+            canHandle() { return true; }
+            getCompatibilityScore() { return 0.2; }
+        }
+
+        registry.register(new HttpToJsonLowCompat());
+        registry.register(new HttpToGrpcAdapter());
+        registry.register(new GrpcToJsonAdapter());
+        registry.register(new JsonToXmlAdapter());
+
+        const builder = new AdapterChainBuilder(registry);
+        const chain = builder.buildChain(
+            { name: 'HTTP', version: '1.1', capabilities: [], metadata: {} },
+            { name: 'XML', version: '1.0', capabilities: [], metadata: {} }
+        );
+
+        expect(chain).toBeTruthy();
+        const adapters = chain!.getAdapters();
+        expect(adapters.some(a => a instanceof HttpToJsonLowCompat)).toBe(false);
+    });
+});

--- a/src/tests/implementations/grpc-json.test.ts
+++ b/src/tests/implementations/grpc-json.test.ts
@@ -1,0 +1,54 @@
+import { GrpcToJsonAdapter } from '../../implementations/grpc-json.adapter.js';
+
+describe('GrpcToJsonAdapter', () => {
+    let adapter: GrpcToJsonAdapter;
+
+    beforeEach(() => {
+        adapter = new GrpcToJsonAdapter();
+    });
+
+    describe('adapt', () => {
+        it('should convert gRPC message to JSON', async () => {
+            const data = { message: new TextEncoder().encode(JSON.stringify({ foo: 'bar' })) };
+            const result = await adapter.adapt(data);
+            expect(result).toEqual({ foo: 'bar' });
+        });
+    });
+
+    describe('reverse', () => {
+        it('should convert JSON to gRPC response', async () => {
+            const json = { foo: 'bar' };
+            const result = await adapter.reverse(json);
+            expect(result.response).toBeInstanceOf(Uint8Array);
+            expect(JSON.parse(new TextDecoder().decode(result.response))).toEqual(json);
+        });
+    });
+
+    describe('canHandle', () => {
+        it('should return true for gRPC to JSON', () => {
+            expect(
+                adapter.canHandle(
+                    { name: 'gRPC', version: '1.0', capabilities: [], metadata: {} },
+                    { name: 'JSON', version: '1.0', capabilities: [], metadata: {} }
+                )
+            ).toBe(true);
+        });
+
+        it('should return false for unsupported protocols', () => {
+            expect(
+                adapter.canHandle(
+                    { name: 'HTTP', version: '1.1', capabilities: [], metadata: {} },
+                    { name: 'JSON', version: '1.0', capabilities: [], metadata: {} }
+                )
+            ).toBe(false);
+        });
+    });
+
+    describe('getCompatibilityScore', () => {
+        it('should return a score between 0 and 1', () => {
+            const score = adapter.getCompatibilityScore();
+            expect(score).toBeGreaterThan(0);
+            expect(score).toBeLessThanOrEqual(1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- make `AdapterChain` generic with helper getters
- choose optimal adapter chain using compatibility scores
- test new adapter chain behaviour
- add unit tests for `GrpcToJsonAdapter`

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*