### PR TITLE
Add CSV adapter and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ Concept - Work in progress...
 
 ## Goal
 Create a universal adapter system capable of transforming and connecting any protocol to any other protocol, enabling seamless interoperability between different systems and standards.
+
+## Available Adapters
+- **HTTP to gRPC** – convert RESTful HTTP requests into gRPC calls.
+- **gRPC to JSON** – decode gRPC messages into JSON objects.
+- **JSON to XML** – serialize JSON structures into XML and back.
+- **CSV to JSON** – parse CSV data into JSON arrays and generate CSV.
+
+These adapters can be combined using the `AdapterRegistry` and `AdapterChain` utilities to create complex protocol transformations.

--- a/src/implementations/csv-json.adapter.ts
+++ b/src/implementations/csv-json.adapter.ts
@@ -1,0 +1,72 @@
+import { Protocol, ProtocolAdapter, AdapterContext } from '../core/adapter.js';
+
+interface CsvProtocol extends Protocol {
+    delimiter: string;
+    headers?: string[];
+}
+
+interface JsonProtocol extends Protocol {
+    schema?: Record<string, any>;
+}
+
+export class CsvToJsonAdapter implements ProtocolAdapter<CsvProtocol, JsonProtocol> {
+    sourceProtocol: CsvProtocol = {
+        name: 'CSV',
+        version: '1.0',
+        capabilities: ['Delimited'],
+        metadata: {},
+        delimiter: ',',
+        headers: []
+    };
+
+    targetProtocol: JsonProtocol = {
+        name: 'JSON',
+        version: '1.0',
+        capabilities: ['Nested', 'Arrays'],
+        metadata: {},
+        schema: {}
+    };
+
+    async adapt(data: string, context?: AdapterContext): Promise<any[]> {
+        const delimiter = this.sourceProtocol.delimiter;
+        const lines = data.trim().split(/\r?\n/);
+        if (!lines.length) {
+            return [];
+        }
+        const headers = this.sourceProtocol.headers && this.sourceProtocol.headers.length
+            ? this.sourceProtocol.headers
+            : lines.shift()!.split(delimiter);
+
+        return lines.map(line => {
+            const values = line.split(delimiter);
+            const obj: Record<string, any> = {};
+            for (let i = 0; i < headers.length; i++) {
+                obj[headers[i]] = values[i] ?? '';
+            }
+            return obj;
+        });
+    }
+
+    async reverse(data: any[], context?: AdapterContext): Promise<string> {
+        if (!Array.isArray(data) || data.length === 0) {
+            return '';
+        }
+        const delimiter = this.sourceProtocol.delimiter;
+        const headers = this.sourceProtocol.headers && this.sourceProtocol.headers.length
+            ? this.sourceProtocol.headers
+            : Object.keys(data[0]);
+        const lines = [headers.join(delimiter)];
+        for (const row of data) {
+            lines.push(headers.map(h => row[h] ?? '').join(delimiter));
+        }
+        return lines.join('\n');
+    }
+
+    canHandle(source: Protocol, target: Protocol): boolean {
+        return source.name === 'CSV' && target.name === 'JSON';
+    }
+
+    getCompatibilityScore(): number {
+        return 0.75;
+    }
+}

--- a/src/tests/core/adapter-chain.test.ts
+++ b/src/tests/core/adapter-chain.test.ts
@@ -3,6 +3,7 @@ import { AdapterChainBuilder } from '../../core/adapter-chain.js';
 import { HttpToGrpcAdapter } from '../../implementations/http-grpc.adapter.js';
 import { GrpcToJsonAdapter } from '../../implementations/grpc-json.adapter.js';
 import { JsonToXmlAdapter } from '../../implementations/json-xml.adapter.js';
+import { CsvToJsonAdapter } from '../../implementations/csv-json.adapter.js';
 import { createMockContext } from '../utils/test-helpers.js';
 
 describe('AdapterChainBuilder', () => {
@@ -56,5 +57,23 @@ describe('AdapterChainBuilder', () => {
         expect(chain).toBeTruthy();
         const adapters = chain!.getAdapters();
         expect(adapters.some(a => a instanceof HttpToJsonLowCompat)).toBe(false);
+    });
+
+    it('should build a chain from CSV to XML', async () => {
+        const registry = new AdapterRegistry();
+        registry.register(new CsvToJsonAdapter());
+        registry.register(new JsonToXmlAdapter());
+
+        const builder = new AdapterChainBuilder(registry);
+        const chain = builder.buildChain(
+            { name: 'CSV', version: '1.0', capabilities: [], metadata: {} },
+            { name: 'XML', version: '1.0', capabilities: [], metadata: {} }
+        );
+
+        expect(chain).toBeTruthy();
+
+        const csv = 'name,age\nAlice,30';
+        const xml = await chain!.adapt(csv, createMockContext());
+        expect(xml).toContain('<name>Alice</name>');
     });
 });

--- a/src/tests/edge-cases/csv-json.edge.test.ts
+++ b/src/tests/edge-cases/csv-json.edge.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Edge case tests for CSV to JSON adapter
+ */
+
+import { CsvToJsonAdapter } from '../../implementations/csv-json.adapter.js';
+
+describe('CsvToJsonAdapter Edge Cases', () => {
+    let adapter: CsvToJsonAdapter;
+
+    beforeEach(() => {
+        adapter = new CsvToJsonAdapter();
+    });
+
+    describe('adapt edge cases', () => {
+        it('should return empty array for empty input', async () => {
+            const result = await adapter.adapt('');
+            expect(result).toEqual([]);
+        });
+
+        it('should handle rows with missing values', async () => {
+            const csv = 'name,age\nAlice\nBob,25';
+            const result = await adapter.adapt(csv);
+            expect(result).toEqual([
+                { name: 'Alice', age: '' },
+                { name: 'Bob', age: '25' }
+            ]);
+        });
+
+        it('should parse quoted values containing delimiter', async () => {
+            const csv = 'name,desc\n"Widget, A",simple';
+            const result = await adapter.adapt(csv);
+            expect(result[0].name).toBe('Widget, A');
+        });
+    });
+});

--- a/src/tests/implementations/csv-json.test.ts
+++ b/src/tests/implementations/csv-json.test.ts
@@ -1,0 +1,59 @@
+import { CsvToJsonAdapter } from '../../implementations/csv-json.adapter.js';
+
+describe('CsvToJsonAdapter', () => {
+    let adapter: CsvToJsonAdapter;
+
+    beforeEach(() => {
+        adapter = new CsvToJsonAdapter();
+    });
+
+    describe('adapt', () => {
+        it('should convert CSV string to JSON array', async () => {
+            const csv = 'name,age\nAlice,30\nBob,25';
+            const result = await adapter.adapt(csv);
+            expect(result).toEqual([
+                { name: 'Alice', age: '30' },
+                { name: 'Bob', age: '25' }
+            ]);
+        });
+    });
+
+    describe('reverse', () => {
+        it('should convert JSON array to CSV string', async () => {
+            const json = [
+                { name: 'Alice', age: 30 },
+                { name: 'Bob', age: 25 }
+            ];
+            const result = await adapter.reverse(json);
+            expect(result.trim()).toBe('name,age\nAlice,30\nBob,25');
+        });
+    });
+
+    describe('canHandle', () => {
+        it('should return true for CSV to JSON', () => {
+            expect(
+                adapter.canHandle(
+                    { name: 'CSV', version: '1.0', capabilities: [], metadata: {} },
+                    { name: 'JSON', version: '1.0', capabilities: [], metadata: {} }
+                )
+            ).toBe(true);
+        });
+
+        it('should return false for unsupported protocols', () => {
+            expect(
+                adapter.canHandle(
+                    { name: 'XML', version: '1.0', capabilities: [], metadata: {} },
+                    { name: 'JSON', version: '1.0', capabilities: [], metadata: {} }
+                )
+            ).toBe(false);
+        });
+    });
+
+    describe('getCompatibilityScore', () => {
+        it('should return a score between 0 and 1', () => {
+            const score = adapter.getCompatibilityScore();
+            expect(score).toBeGreaterThan(0);
+            expect(score).toBeLessThanOrEqual(1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- implement `CsvToJsonAdapter`
- document available adapters in README
- test `CsvToJsonAdapter`
- test adapter chain with CSV input
- add edge case tests for CSV adapter

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: TS2304: Cannot find name 'jest')*