### PR TITLE
Add adapter removal feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ const adapter = registry.findAdapter(
 );
 
 const grpcReq = await adapter?.adapt({ method: 'GET', path: '/users', body: {} });
+
+// Unregister adapters when they are no longer needed
+registry.unregister(
+  { name: 'HTTP', version: '1.1', capabilities: [], metadata: {} },
+  { name: 'gRPC', version: '1.0', capabilities: [], metadata: {} }
+);
 ```
 
 See `src/examples/adapter.test.ts` for additional demonstrations.

--- a/src/core/adapter.ts
+++ b/src/core/adapter.ts
@@ -87,6 +87,15 @@ export class AdapterRegistry {
     }
 
     /**
+     * Remove an adapter for the given protocols
+     * @returns true if an adapter was removed
+     */
+    unregister(source: Protocol, target: Protocol): boolean {
+        const key = this.getAdapterKey(source, target);
+        return this.adapters.delete(key);
+    }
+
+    /**
      * Find an adapter that can transform between given protocols
      */
     findAdapter(source: Protocol, target: Protocol): ProtocolAdapter<any, any> | null {

--- a/src/tests/core/adapter.test.ts
+++ b/src/tests/core/adapter.test.ts
@@ -37,6 +37,35 @@ describe('AdapterRegistry', () => {
         });
     });
 
+    describe('unregister', () => {
+        it('should remove an existing adapter', () => {
+            const mockAdapter = createMockAdapter('Protocol1', 'Protocol2');
+            registry.register(mockAdapter);
+
+            const removed = registry.unregister(
+                { name: 'Protocol1', version: '1.0', capabilities: [], metadata: {} },
+                { name: 'Protocol2', version: '1.0', capabilities: [], metadata: {} }
+            );
+
+            expect(removed).toBe(true);
+            const found = registry.findAdapter(
+                { name: 'Protocol1', version: '1.0', capabilities: [], metadata: {} },
+                { name: 'Protocol2', version: '1.0', capabilities: [], metadata: {} }
+            );
+
+            expect(found).toBeNull();
+        });
+
+        it('should return false when no adapter exists', () => {
+            const removed = registry.unregister(
+                { name: 'Nope', version: '1.0', capabilities: [], metadata: {} },
+                { name: 'None', version: '1.0', capabilities: [], metadata: {} }
+            );
+
+            expect(removed).toBe(false);
+        });
+    });
+
     describe('findAdapter', () => {
         it('should find adapter by exact protocol match', () => {
             const mockAdapter = createMockAdapter('Protocol1', 'Protocol2');


### PR DESCRIPTION
## Summary
- allow unregistering adapters from AdapterRegistry
- document usage of `registry.unregister` in README
- test AdapterRegistry.unregister behavior

## Testing
- `npm test` *(fails: Cannot find module 'jest')*